### PR TITLE
depreciate ordinal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,7 @@ import css from "./css/choropleth.css";
 
     // Else go over available scheme types
     switch (options.colorScheme) {
-      case 'ordinal':
+      case 'qualitative':
         var domain = [], range = [];
         for (let idx in options.colorData) {
           if (options.colorData.hasOwnProperty(idx)) {
@@ -522,9 +522,8 @@ import css from "./css/choropleth.css";
     // @todo - determine the ways of generating various combinations of
     // scales and classifications
 
-    // Render simple legend (ordinal)
-    if (['qualitative'].indexOf(this.options.colorScheme)) {
-
+    // Render simple legend (qualitative)
+    if (this.options.colorScheme == 'qualitative') {
       this.legend.attr('class', 'choropleth--legend choropleth--legend--' + this.options.colorScheme);
       for (var v of this.colorScale.domain()) {
         var c = this.colorScale(v),


### PR DESCRIPTION
This commit cleans up the usage of `ordinal` as an option for the color scheme. 

The library has now replaced it with `qualitative` along with a few variants.

- When `colorData` is empty, it will use the default blue color scheme.
- When `colorData` has an array or object it will manually use those values.

