### PR TITLE
Map data better

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,10 +251,17 @@ import css from "./css/choropleth.css";
     if (!topo.objects.hasOwnProperty(feature)) {
       return topo;
     }
+
+    // create an array that maps the FIPS id's in the dataset to check against later
+    var dataFips = [];
+    for (var i = 0; i < data.length; i++) {
+      dataFips[Number(data[i].id)] = i;
+    }
+
     for (var i = 0; i < topo.objects[feature].geometries.length; i++) {
       var id = Number(topo.objects[feature].geometries[i].id);
-      if (data.hasOwnProperty(id)) {
-        Object.assign(topo.objects[feature].geometries[i].properties, data[id]);
+      if (dataFips.hasOwnProperty(id)) {
+        Object.assign(topo.objects[feature].geometries[i].properties, data[dataFips[id]]);
       }
     }
     return topo;


### PR DESCRIPTION
So currently the data must be indexed by the FIPS ID. This is cumbersome as data could be passed in some other order and requires extra unnecessary effort when integrating.

This PR changes how that works. Now instead of all that, each data array/object simply needs an `id` key that syncs up with whatever style FIPS you are using, just be sure it matches the topography data. 