### PR TITLE
Enable grayscale and data range scanning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,7 @@ import css from "./css/choropleth.css";
 
     // Else go over available scheme types
     switch (options.colorScheme) {
-      case 'ordinal':
+      case 'qualitative':
         var domain = [], range = [];
         for (let idx in options.colorData) {
           if (options.colorData.hasOwnProperty(idx)) {
@@ -522,9 +522,8 @@ import css from "./css/choropleth.css";
     // @todo - determine the ways of generating various combinations of
     // scales and classifications
 
-    // Render simple legend (ordinal)
-    if (['qualitative'].indexOf(this.options.colorScheme)) {
-
+    // Render simple legend (qualitative)
+    if (this.options.colorScheme == 'qualitative') {
       this.legend.attr('class', 'choropleth--legend choropleth--legend--' + this.options.colorScheme);
       for (var v of this.colorScale.domain()) {
         var c = this.colorScale(v),

--- a/src/index.js
+++ b/src/index.js
@@ -187,6 +187,10 @@ import css from "./css/choropleth.css";
     }
   }
 
+  function getFileTypeFromPath(filepath) {
+    return filepath.split('\\').pop().split('/').pop().split('.').pop();
+  }
+
   /**
    * Fetches specified Topology data
    * @param name
@@ -203,10 +207,14 @@ import css from "./css/choropleth.css";
 
         // If given a file path to the map data, load it
         if (typeof SELF.options.data === 'string') {
-          d3.json(SELF.options.data)
+          // can be either a json file or csv
+          var filetype = getFileTypeFromPath(SELF.options.data);
+          if (filetype === 'json' || filetype === 'csv') {
+            d3[filetype](SELF.options.data)
             .then(function(file) {
               cb(null, file);
             });
+          }
         }
       }).defer(function (cb) {
         // When either set or layer is not defined
@@ -220,6 +228,7 @@ import css from "./css/choropleth.css";
         }
 
         // Otherwise load data from local plugin storage in the 'topology' folder
+        // these are for now just json files
         d3.json(_path + 'topology/' + name + '/' + _topo[name][layer].file)
           .then(function(file) {
             if (typeof SELF.options.alterTopography === 'function') {


### PR DESCRIPTION
This is a first pass at enabling another style of progression. The concept of mapping the range of values in the dataset and passing that into the color scale methods is introduced.

This includes basic legend support, but also outlines how much classification could really help. If that existed, the legend would be much more helpful. We could better convey the data being shown.